### PR TITLE
Clear screen before backlight

### DIFF
--- a/display_panel.cpp
+++ b/display_panel.cpp
@@ -232,6 +232,10 @@ void esp_panel_init()
   // setRotation(0);  // Set screen orientation if needed
   lcd->displayOn();
 
+  static uint16_t black_frame[screenWidth * screenHeight];
+  memset(black_frame, 0, sizeof(black_frame));
+  lcd->drawBitmap(0, 0, screenWidth, screenHeight, (uint8_t *)black_frame);
+
   screen_switch(true);
   backlight->setBrightness(100); // Set brightness
 }


### PR DESCRIPTION
## Summary
- Clear screen with a black frame buffer before turning on backlight to show blank boot screen

## Testing
- `g++ -fsyntax-only -std=c++17 display_panel.cpp` *(fails: lvgl.h: No such file or directory)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6897f7118050832b97fefdcb0c44dac6